### PR TITLE
[Sign] 비밀번호찾기 서버 연동

### DIFF
--- a/src/components/find-password/FindPasswordForm.tsx
+++ b/src/components/find-password/FindPasswordForm.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import SmallButton from '@/components/common/SmallButton';
 import TextField from '@/components/common/TextField';
 import InputItem from '@/types/InputForm';
 
@@ -11,9 +12,10 @@ type FindPasswordFormProps = {
     password: InputItem<string>;
     passwordConfirm: InputItem<string>;
   }
+  onResend: () => void;
 };
 
-export default function FindPasswordForm({ step, formData }:FindPasswordFormProps) {
+export default function FindPasswordForm({ step, formData, onResend }:FindPasswordFormProps) {
   const {
     email, certificationNumber, password, passwordConfirm,
   } = formData;
@@ -35,15 +37,18 @@ export default function FindPasswordForm({ step, formData }:FindPasswordFormProp
 
     if (currStep === 1) {
       return (
-        <TextField
-          label="인증번호"
-          placeholder="6자리 숫자"
-          type="number"
-          register={certificationNumber.register}
-          value={certificationNumber.value}
-          error={certificationNumber.error}
-          onClickReset={certificationNumber.onClickReset}
-        />
+        <>
+          <TextField
+            label="인증번호"
+            placeholder="6자리 숫자"
+            type="number"
+            register={certificationNumber.register}
+            value={certificationNumber.value}
+            error={certificationNumber.error}
+            onClickReset={certificationNumber.onClickReset}
+          />
+          <SmallButton onClick={onResend}>인증번호 재전송</SmallButton>
+        </>
       );
     }
 

--- a/src/components/find-password/index.tsx
+++ b/src/components/find-password/index.tsx
@@ -8,13 +8,13 @@ import useFindPasswordForm from '@/hooks/useFindPasswordForm';
 
 export default function FindPassword() {
   const {
-    step, isActive, formData, onSubmit, popInfo,
+    step, isActive, formData, onSubmit, popInfo, onResend,
   } = useFindPasswordForm();
 
   return (
     <Container onSubmit={onSubmit}>
       <StepTitle step={step} />
-      <FindPasswordForm step={step} formData={formData} />
+      <FindPasswordForm step={step} formData={formData} onResend={onResend} />
       <StepButton step={step} isActive={isActive} />
       <NormalPopup {...popInfo} />
     </Container>

--- a/src/components/find-password/index.tsx
+++ b/src/components/find-password/index.tsx
@@ -3,11 +3,12 @@ import styled from 'styled-components';
 import FindPasswordForm from '@/components/find-password/FindPasswordForm';
 import StepButton from '@/components/find-password/StepButton';
 import StepTitle from '@/components/find-password/StepTitle';
+import NormalPopup from '@/components/popup/NormalPopup';
 import useFindPasswordForm from '@/hooks/useFindPasswordForm';
 
 export default function FindPassword() {
   const {
-    step, isActive, formData, onSubmit,
+    step, isActive, formData, onSubmit, popInfo,
   } = useFindPasswordForm();
 
   return (
@@ -15,6 +16,7 @@ export default function FindPassword() {
       <StepTitle step={step} />
       <FindPasswordForm step={step} formData={formData} />
       <StepButton step={step} isActive={isActive} />
+      <NormalPopup {...popInfo} />
     </Container>
   );
 }

--- a/src/components/popup/NormalPopup.tsx
+++ b/src/components/popup/NormalPopup.tsx
@@ -2,23 +2,16 @@ import { MouseEvent } from 'react';
 
 import styled from 'styled-components';
 
+import PopInfo from '@/types/PopInfo';
+
 import PopupButtons from './PopupButtons';
 import Portal from './Portal';
 import SprintMotion from './SprintMotion';
 
-type NormalPopupProps = {
-  show: boolean;
-  onClose: () => void;
-  title: string;
-  okText: string;
-  cancelText?: string;
-  onOk?: ()=>void;
-};
-
 export default function NormalPopup({
   show, onClose, title,
   okText, cancelText, onOk,
-}:NormalPopupProps) {
+}:PopInfo) {
   const onStopPropagation = (e: MouseEvent) => e.stopPropagation();
 
   return (
@@ -67,7 +60,9 @@ const Title = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
   width: 100%;
   height: 78px;
   border-bottom: 1px solid ${({ theme }) => theme.color.gray00};
+  white-space: pre-wrap;
 `;

--- a/src/fixtures/authenticate.ts
+++ b/src/fixtures/authenticate.ts
@@ -1,5 +1,5 @@
 const authenticate = {
-  code: 200,
+  code: 0,
   message: 'success',
   value: {
     token: 'test-token',

--- a/src/hooks/api/useChangePasswordMutation.test.ts
+++ b/src/hooks/api/useChangePasswordMutation.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+
+import useChangePasswordMutation from '@/hooks/api/useChangePasswordMutation';
+import { apiService } from '@/lib/api/ApiService';
+import wrapper from '@/test/ReactQueryWrapper';
+
+jest.mock('@/lib/api/ApiService');
+
+describe('useChangePasswordMutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (apiService.passwordMissing as jest.Mock).mockImplementation(() => ({
+      code: 0,
+      value: {
+        userId: 100,
+      },
+    }));
+  });
+
+  const renderUseChangePasswordMutationHook = () => renderHook(
+    () => useChangePasswordMutation(),
+    {
+      wrapper,
+    },
+  );
+
+  // eslint-disable-next-line jest/expect-expect
+  it('호출 Test', async () => {
+    const { result } = renderUseChangePasswordMutationHook();
+
+    await result.current.passwordMissingMutation.mutate({ email: 'popo@gmail.com' });
+    await result.current.passwordMissingAuthMutation.mutate({ userId: 100, userCode: '1234' });
+    await result.current.passwordResetMutation.mutate({ userId: 100, toChangePassword: '1234' });
+  });
+});

--- a/src/hooks/api/useChangePasswordMutation.ts
+++ b/src/hooks/api/useChangePasswordMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { apiService } from '@/lib/api/ApiService';
+
+export default function useChangePasswordMutation() {
+  const passwordMissingMutation = useMutation(
+    (payload: { email:string }) => apiService.passwordMissing(payload),
+  );
+
+  const passwordMissingAuthMutation = useMutation(
+    (payload: { userId?: number, userCode: string }) => apiService.passwordMissingAuth(payload),
+  );
+
+  const passwordResetMutation = useMutation(
+    (payload: { userId?: number, toChangePassword: string }) => apiService.passwordReset(payload),
+  );
+
+  return {
+    passwordMissingMutation,
+    passwordMissingAuthMutation,
+    passwordResetMutation,
+  };
+}

--- a/src/hooks/api/useGetInfiniteSchool.test.ts
+++ b/src/hooks/api/useGetInfiniteSchool.test.ts
@@ -22,11 +22,9 @@ describe('useGetSchool', () => {
 
     (apiService.fetchGetSchools as jest.Mock).mockImplementation(() => (
       {
-        data: {
-          content: fixtures.school,
-          last: given.last,
-          first: given.first,
-        },
+        content: fixtures.school,
+        last: given.last,
+        first: given.first,
       }
     ));
     (useInView as jest.Mock).mockImplementation(() => ({

--- a/src/hooks/api/useGetInfiniteSchool.ts
+++ b/src/hooks/api/useGetInfiniteSchool.ts
@@ -15,13 +15,13 @@ export default function useGetInfiniteSchool({ keyword }:GetSchoolProps) {
     [GET_INFINITE_SCHOOLS_KEY, keyword],
     async ({ pageParam = 0 }) => apiService.fetchGetSchools({ keyword, page: pageParam }),
     {
-      getNextPageParam: (lastPage) => {
-        if (lastPage.data.last) return undefined;
-        return lastPage.data.number + 1;
+      getNextPageParam: (res) => {
+        if (res.last) return undefined;
+        return res.number + 1;
       },
-      getPreviousPageParam: (firstPage) => {
-        if (firstPage.data.first) return undefined;
-        return firstPage.data.number - 1;
+      getPreviousPageParam: (res) => {
+        if (res.first) return undefined;
+        return res.number - 1;
       },
       enabled: keyword.length >= 2,
     },
@@ -37,7 +37,7 @@ export default function useGetInfiniteSchool({ keyword }:GetSchoolProps) {
   });
 
   const schoolData = query.data ? _.flatten(
-    query.data.pages.map((page) => page.data.content),
+    query.data.pages.map((res) => res.content),
   ) : [];
 
   const isEmpty = schoolData.length === 0;

--- a/src/hooks/useFindPasswordForm.test.ts
+++ b/src/hooks/useFindPasswordForm.test.ts
@@ -2,12 +2,14 @@ import { useForm } from 'react-hook-form';
 
 import { useRouter } from 'next/navigation';
 
-import { act, renderHook } from '@testing-library/react';
-import _ from 'lodash/fp';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 import testRegister from '@/fixtures/testRegister';
-import useFindPasswordForm, { FindPasswordForm, FindPasswordName } from '@/hooks/useFindPasswordForm';
+import { apiService } from '@/lib/api/ApiService';
+import wrapper from '@/test/ReactQueryWrapper';
 import { getTestForm } from '@/utils/testHelper';
+
+import useFindPasswordForm, { FindPasswordForm, FindPasswordName } from './useFindPasswordForm';
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -17,8 +19,11 @@ jest.mock('react-hook-form', () => ({
   useForm: jest.fn(),
 }));
 
+jest.mock('@/lib/api/ApiService');
+
 describe('useFindPasswordForm', () => {
   const routerReplace = jest.fn();
+  const routerPush = jest.fn();
 
   const {
     resetField, formState, setError, setFocus,
@@ -32,17 +37,18 @@ describe('useFindPasswordForm', () => {
 
   const handleSubmit = (onValid: (data:FindPasswordForm)=>void) => () => {
     onValid({
-      email: given.name,
-      certificationNumber: given.certificationNumber,
-      password: given.password,
-      passwordConfirm: given.passwordConfirm,
+      email: watch('email'),
+      certificationNumber: watch('certificationNumber'),
+      password: (watch('password')),
+      passwordConfirm: (watch('passwordConfirm')),
     });
   };
-  const watch = (name: FindPasswordName) => given[name];
+  const watch = (name: FindPasswordName) => name;
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useRouter as jest.Mock).mockImplementation(() => ({
+      push: routerPush,
       replace: routerReplace,
     }));
     (useForm as jest.Mock).mockImplementation(() => ({
@@ -54,75 +60,164 @@ describe('useFindPasswordForm', () => {
       setFocus,
       handleSubmit,
     }));
+    (apiService.passwordMissing as jest.Mock).mockImplementation(() => given.passwordMissing);
+    (apiService.passwordMissingAuth as jest.Mock).mockImplementation(
+      () => given.passwordMissingAuth,
+    );
+    (apiService.passwordReset as jest.Mock).mockImplementation(
+      () => given.passwordReset,
+    );
   });
 
   const renderFindPasswordFormHook = () => renderHook(
     () => useFindPasswordForm(),
+    {
+      wrapper,
+    },
   );
 
-  context('step별 submit event test', () => {
-    it('STEP 0', () => {
-      const { result } = renderFindPasswordFormHook();
+  describe('step별 submit event test', () => {
+    describe('step0', () => {
+      it('step0 submit success', async () => {
+        given('passwordMissing', () => ({ code: 0, value: { userId: 100 } }));
+        const { result } = renderFindPasswordFormHook();
 
-      expect(result.current.step).toEqual(0);
-    });
-    it('STEP 1', () => {
-      const { result } = renderFindPasswordFormHook();
+        expect(result.current.step).toEqual(0);
 
-      act(() => {
-        result.current.onSubmit();
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+
+        expect(result.current.popInfo.show).toEqual(false);
+        expect(result.current.step).toEqual(1);
       });
 
-      expect(result.current.step).toEqual(1);
-    });
-    it('STEP 2', () => {
-      const { result } = renderFindPasswordFormHook();
+      it('step0 submit failed', async () => {
+        given('passwordMissing', () => Promise.reject());
+        const { result } = renderFindPasswordFormHook();
 
-      Array.from({ length: 2 }).forEach(() => {
+        expect(result.current.step).toEqual(0);
+
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+
+        expect(result.current.popInfo.show).toEqual(true);
+
+        if (result.current.popInfo.onOk) {
+          result.current.popInfo.onOk();
+        }
+        expect(routerPush).toHaveBeenCalledWith('/signup');
+
         act(() => {
+          result.current.popInfo.onClose();
+        });
+
+        expect(result.current.popInfo.show).toEqual(false);
+      });
+    });
+    describe('step1', () => {
+      it('step1 submit success', async () => {
+        given('passwordMissing', () => ({ code: 0, value: { userId: 100 } }));
+        given('passwordMissingAuth', () => ({ code: 0, message: 'ok' }));
+
+        const { result } = renderFindPasswordFormHook();
+
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+        await waitFor(() => {
           result.current.onSubmit();
+        });
+
+        await waitFor(() => {
+          expect(result.current.step).toEqual(2);
         });
       });
 
-      expect(result.current.step).toEqual(2);
-    });
-    it('password === passwordConfirm router replace', () => {
-      given('password', () => '12345678');
-      given('passwordConfirm', () => '12345678');
-      const { result } = renderFindPasswordFormHook();
+      it('step1 submit failed', async () => {
+        given('passwordMissing', () => ({ code: 0, value: { userId: 100 } }));
+        given('passwordMissingAuth', () => Promise.reject());
 
-      Array.from({ length: 3 }).forEach(() => {
-        act(() => {
+        const { result } = renderFindPasswordFormHook();
+
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+        await waitFor(() => {
           result.current.onSubmit();
         });
+
+        await waitFor(() => {
+          expect(result.current.popInfo.show).toEqual(true);
+        });
+
+        act(() => {
+          result.current.popInfo.onClose();
+        });
+
+        expect(result.current.popInfo.show).toEqual(false);
+      });
+    });
+
+    describe('step2', () => {
+      it('step2 submit success', async () => {
+        given('passwordMissing', () => ({ code: 0, value: { userId: 100 } }));
+        given('passwordMissingAuth', () => ({ code: 0, message: 'ok' }));
+        given('passwordReset', () => ({ code: 0, message: 'ok' }));
+
+        const { result } = renderFindPasswordFormHook();
+
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+
+        await act(async () => {
+          await result.current.onSubmit();
+        });
+
+        await waitFor(() => {
+          expect(result.current.popInfo.show).toEqual(true);
+        });
+
+        result.current.popInfo.onClose();
+
+        expect(routerPush).toHaveBeenCalledWith('/signin');
       });
 
-      expect(routerReplace).toHaveBeenCalled();
-    });
-  });
+      it('step2 submit failed', async () => {
+        given('passwordMissing', () => ({ code: 0, value: { userId: 100 } }));
+        given('passwordMissingAuth', () => ({ code: 0, message: 'ok' }));
+        given('passwordReset', () => Promise.reject());
 
-  context('passwordConfirm Validation Test', () => {
-    it('password === passwordConfirm', () => {
-      given('password', () => '12345678');
+        const { result } = renderFindPasswordFormHook();
 
-      const { result } = renderFindPasswordFormHook();
+        await act(async () => {
+          await result.current.onSubmit();
+        });
 
-      const { passwordConfirm } = result.current.formData;
+        await act(async () => {
+          await result.current.onSubmit();
+        });
 
-      const validate = _.get('register.validate')(passwordConfirm);
+        await act(async () => {
+          await result.current.onSubmit();
+        });
 
-      expect(validate('12345678')).toBe(true);
-    });
-    it('password !== passwordConfirm', () => {
-      given('password', () => '12345678');
+        await waitFor(() => {
+          expect(result.current.popInfo.show).toEqual(true);
+        });
 
-      const { result } = renderFindPasswordFormHook();
+        act(() => {
+          result.current.popInfo.onClose();
+        });
 
-      const { passwordConfirm } = result.current.formData;
-
-      const validate = _.get('register.validate')(passwordConfirm);
-
-      expect(validate('123456789')).toBe('비밀번호가 일치하지 않습니다.');
+        expect(result.current.popInfo.show).toEqual(false);
+      });
     });
   });
 

--- a/src/hooks/useFindPasswordForm.test.ts
+++ b/src/hooks/useFindPasswordForm.test.ts
@@ -255,4 +255,20 @@ describe('useFindPasswordForm', () => {
       expect(setFocus).toHaveBeenCalledWith('passwordConfirm');
     });
   });
+
+  it('onResend Test', async () => {
+    const { result } = renderFindPasswordFormHook();
+
+    result.current.onResend();
+
+    await waitFor(() => {
+      expect(result.current.popInfo.show).toEqual(true);
+    });
+
+    act(() => {
+      result.current.popInfo.onClose();
+    });
+
+    expect(result.current.popInfo.show).toEqual(false);
+  });
 });

--- a/src/hooks/useFindPasswordForm.ts
+++ b/src/hooks/useFindPasswordForm.ts
@@ -2,6 +2,9 @@ import { useCallback, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import useChangePasswordMutation from '@/hooks/api/useChangePasswordMutation';
+import PopInfo, { getDefaultPopInfo } from '@/types/PopInfo';
+
 import usePoPoForm from './usePoPoForm';
 
 export type FindPasswordName = 'email' | 'certificationNumber' | 'password' | 'passwordConfirm';
@@ -17,10 +20,18 @@ const useFindPasswordForm = () => {
   const router = useRouter();
 
   const [step, setStep] = useState(0);
+  const [userId, setUserId] = useState<undefined | number>();
+  const [popInfo, setPopInfo] = useState<PopInfo>(getDefaultPopInfo());
 
   const {
     watch, getError, getDefaultRegister, getActiveCheck, reset, handleSubmit,
   } = usePoPoForm<FindPasswordForm>();
+
+  const {
+    passwordMissingMutation,
+    passwordMissingAuthMutation,
+    passwordResetMutation,
+  } = useChangePasswordMutation();
 
   const getActive = useCallback((currentStep: number) => {
     if (currentStep === 0) {
@@ -34,12 +45,72 @@ const useFindPasswordForm = () => {
   }, [getActiveCheck]);
 
   const onSubmit = handleSubmit(() => {
-    if (step < 2) {
-      setStep((prev) => prev + 1);
+    if (step === 0) {
+      passwordMissingMutation.mutate({
+        email: watch('email'),
+      }, {
+        onSuccess: (data) => {
+          setUserId(data.value.userId);
+          setStep(1);
+        },
+        onError: () => {
+          setPopInfo({
+            show: true,
+            title: '등록된 이메일이 없어요\n회원가입하시겠어요?',
+            okText: '회원가입',
+            cancelText: '취소',
+            onOk: () => router.push('/signup'),
+            onClose: () => setPopInfo(getDefaultPopInfo()),
+          });
+        },
+      });
+
+      return;
+    }
+    if (step === 1) {
+      passwordMissingAuthMutation.mutate({
+        userId,
+        userCode: watch('certificationNumber'),
+      }, {
+        onSuccess: () => {
+          setStep(2);
+        },
+        onError: () => {
+          setPopInfo({
+            show: true,
+            title: '인증번호가 일치하지 않아요.\n다시 확인해주세요.',
+            okText: '확인',
+            onClose: () => setPopInfo(getDefaultPopInfo()),
+          });
+        },
+      });
       return;
     }
 
-    router.replace('/');
+    passwordResetMutation.mutate(
+      {
+        userId,
+        toChangePassword: watch('password'),
+      },
+      {
+        onError: () => {
+          setPopInfo({
+            show: true,
+            title: '이전 비밀번호와 동일한 비밀번호를\n사용할 수 없어요.',
+            okText: '확인',
+            onClose: () => setPopInfo(getDefaultPopInfo()),
+          });
+        },
+        onSuccess: () => {
+          setPopInfo({
+            show: true,
+            title: '비밀번호를 성공적으로 변경했어요.\n새로운 비밀번호로 로그인해주세요.',
+            okText: '확인',
+            onClose: () => router.push('/signin'),
+          });
+        },
+      },
+    );
   });
 
   return {
@@ -71,6 +142,7 @@ const useFindPasswordForm = () => {
       },
     },
     isActive: getActive(step),
+    popInfo,
     onSubmit,
   };
 };

--- a/src/hooks/useFindPasswordForm.ts
+++ b/src/hooks/useFindPasswordForm.ts
@@ -113,6 +113,21 @@ const useFindPasswordForm = () => {
     );
   });
 
+  const onResend = () => {
+    passwordMissingMutation.mutate({
+      email: watch('email'),
+    }, {
+      onSuccess: () => {
+        setPopInfo({
+          show: true,
+          title: '인증번호를 재전송했어요.\n인증번호를 입력해주세요.',
+          okText: '확인',
+          onClose: () => setPopInfo(getDefaultPopInfo()),
+        });
+      },
+    });
+  };
+
   return {
     step,
     formData: {
@@ -144,6 +159,7 @@ const useFindPasswordForm = () => {
     isActive: getActive(step),
     popInfo,
     onSubmit,
+    onResend,
   };
 };
 

--- a/src/lib/api/ApiService.test.ts
+++ b/src/lib/api/ApiService.test.ts
@@ -16,6 +16,47 @@ describe('ApiService', () => {
     expect(apiService).not.toBeNull();
   });
 
+  describe('error test', () => {
+    it('Status가 400~500이고 메세지가 있을 때는 에러메세지를 띄움.', async () => {
+      let error = null;
+      mock.onGet('/test').reply(400, { code: 400, message: '에러!!!' });
+
+      try {
+        await mockApiService.get('/test');
+      } catch (e:any) {
+        error = e.message;
+      }
+
+      expect(error).toEqual('에러!!!');
+    });
+
+    it('Status가 400~500이고 에러 메세지가 없을 때는 기본 에러메세지를 띄움.', async () => {
+      let error = null;
+      mock.onGet('/test').reply(400);
+
+      try {
+        await mockApiService.get('/test');
+      } catch (e:any) {
+        error = e.message;
+      }
+
+      expect(error).toEqual('알 수 없는 에러가 발생했어요. 다시 시도해주세요.');
+    });
+
+    it('Status가 200~300이고 에러 메세지가 없을 때는 기본 에러메세지를 띄움.', async () => {
+      let error = null;
+      mock.onGet('/test').reply(200, { code: 400, message: '에러!!!' });
+
+      try {
+        await mockApiService.get('/test');
+      } catch (e:any) {
+        error = e.message;
+      }
+
+      expect(error).toEqual('에러!!!');
+    });
+  });
+
   describe('setToken', () => {
     it('사용자의 토큰 저장', () => {
       mockApiService.setToken('test-token');
@@ -24,19 +65,9 @@ describe('ApiService', () => {
     });
   });
 
-  describe('fetchGetSchools', () => {
-    it('returns schools', async () => {
-      mock.onGet('/school/search').reply(200, { content: fixtures.school });
-
-      const { data } = await mockApiService.fetchGetSchools({ keyword: 'test', page: 0 });
-
-      expect(data.content).toEqual(fixtures.school);
-    });
-  });
-
   describe('authenticate', () => {
-    it('사용자 인증이 성공할 경우', async () => {
-      mock.onPost('/user/authenticate').reply(200, fixtures.authenticate);
+    it('사용자 인증이 성공할 경우 데이터를 리턴한다.', async () => {
+      mock.onPost('/user/authenticate').reply(200, { ...fixtures.authenticate });
 
       const data = await mockApiService.authenticate({ email: 'test@test.com', password: '1234' });
 
@@ -44,12 +75,52 @@ describe('ApiService', () => {
       expect(mockApiService.accessToken).toEqual('test-token');
     });
 
-    it('사용자 인증이 실패할 경우', async () => {
+    it('사용자 인증이 실패할 경우 value값이 없는 데이터를 리턴한다.', async () => {
       mock.onPost('/user/authenticate').reply(200, { ...fixtures.authenticate, value: null });
 
       const data = await mockApiService.authenticate({ email: 'test@test.com', password: '1234' });
 
       expect(data.value).toBeNull();
+    });
+  });
+
+  describe('fetchGetSchools', () => {
+    it('Fetch가 성공할 경우(200) 데이터를 리턴한다.', async () => {
+      mock.onGet('/school/search').reply(200, { code: 0, content: fixtures.school });
+
+      const data = await mockApiService.fetchGetSchools({ keyword: 'test', page: 0 });
+
+      expect(data.content).toEqual(fixtures.school);
+    });
+  });
+
+  describe('passwordMissing', () => {
+    it('요청이 성공할 경우 데이터를 리턴한다.', async () => {
+      mock.onPost('/password/missing').reply(200, { code: 0, value: { userId: 100 } });
+
+      const data = await mockApiService.passwordMissing({ email: 'popo@gmail.com' });
+
+      expect(data.value.userId).toEqual(100);
+    });
+  });
+
+  describe('passwordMissingAuth', () => {
+    it('요청이 성공할 경우 데이터를 리턴한다.', async () => {
+      mock.onPost('/password/missing/auth').reply(200, { code: 0, message: 'ok' });
+
+      const data = await mockApiService.passwordMissingAuth({ userId: 100, userCode: '123456' });
+
+      expect(data.message).toEqual('ok');
+    });
+  });
+
+  describe('passwordReset', () => {
+    it('요청이 성공할 경우 데이터를 리턴한다.', async () => {
+      mock.onPost('/password/reset').reply(200, { code: 0, message: 'ok' });
+
+      const data = await mockApiService.passwordReset({ userId: 100, toChangePassword: '12345678A' });
+
+      expect(data.message).toEqual('ok');
     });
   });
 });

--- a/src/lib/api/ApiService.ts
+++ b/src/lib/api/ApiService.ts
@@ -36,7 +36,6 @@ export default class ApiService {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      withCredentials: true,
     },
   });
 

--- a/src/lib/api/ApiService.ts
+++ b/src/lib/api/ApiService.ts
@@ -1,8 +1,32 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
-import { AuthenticateResponse, GetSchoolsResponse } from '@/types/ApiTypes';
+import ApiException from '@/lib/excptions/ApiException';
+import CustomException from '@/lib/excptions/CustomException';
+import { ApiErrorScheme } from '@/lib/excptions/type';
+import {
+  AuthenticateResponse,
+  GetSchoolsResponse, PasswordMissingAuthResponse,
+  PasswordMissingResponse,
+  PasswordResetResponse,
+} from '@/types/ApiTypes';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+function interceptorResponseFulfilled(res: AxiosResponse) {
+  if (res.data.code === 0) {
+    return res.data;
+  }
+
+  return Promise.reject(res.data);
+}
+
+function interceptorResponseRejected(error: AxiosError<ApiErrorScheme>) {
+  if (error.response?.data?.message) {
+    return Promise.reject(new ApiException(error.response.data, error.response.status));
+  }
+
+  return Promise.reject(new CustomException('알 수 없는 에러가 발생했어요. 다시 시도해주세요.'));
+}
 
 export default class ApiService {
   private instance = axios.create({
@@ -12,8 +36,16 @@ export default class ApiService {
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
+      withCredentials: true,
     },
   });
+
+  constructor() {
+    this.instance.interceptors.response.use(
+      interceptorResponseFulfilled,
+      interceptorResponseRejected,
+    );
+  }
 
   accessToken: string | undefined;
 
@@ -23,7 +55,17 @@ export default class ApiService {
     this.accessToken = accessToken;
   }
 
-  fetchGetSchools = ({ keyword, page }: { keyword: string, page:number }) => this.instance.get<GetSchoolsResponse>('/school/search', {
+  get<T>(...args: Parameters<typeof this.instance.get>) {
+    return this.instance.get<T, T>(...args);
+  }
+
+  post<T>(...args: Parameters<typeof this.instance.post>) {
+    return this.instance.post<T, T>(...args);
+  }
+
+  fetchGetSchools = ({ keyword, page }: {
+    keyword: string, page:number
+  }) => this.get<GetSchoolsResponse>('/school/search', {
     params: {
       keyword,
       size: 30,
@@ -32,7 +74,7 @@ export default class ApiService {
   });
 
   authenticate = async (payload: { email: string, password: string }) => {
-    const { data } = await this.instance.post<AuthenticateResponse>('/user/authenticate', {}, {
+    const data = await this.post<AuthenticateResponse>('/user/authenticate', {}, {
       params: {
         email: payload.email,
         password: payload.password,
@@ -45,6 +87,26 @@ export default class ApiService {
 
     return data;
   };
+
+  passwordMissing = ({ email }: {
+    email:string
+  }) => this.post<PasswordMissingResponse>('/password/missing', {
+    email,
+  });
+
+  passwordMissingAuth = ({ userId, userCode }:{
+    userId?: number, userCode: string
+  }) => this.post<PasswordMissingAuthResponse>('/password/missing/auth', {
+    userId,
+    userCode,
+  });
+
+  passwordReset = ({ userId, toChangePassword }:{
+    userId?: number, toChangePassword: string
+  }) => this.post<PasswordResetResponse>('/password/reset', {
+    userId,
+    toChangePassword,
+  });
 }
 
 export const apiService = new ApiService();

--- a/src/lib/excptions/ApiException.test.ts
+++ b/src/lib/excptions/ApiException.test.ts
@@ -1,0 +1,13 @@
+import ApiException from '@/lib/excptions/ApiException';
+import { ApiErrorScheme } from '@/lib/excptions/type';
+
+describe('ApiException', () => {
+  const createException = (data:ApiErrorScheme, code:number) => new ApiException(data, code);
+
+  it('Api Exception Test', () => {
+    const data = createException({ message: 'test' }, 400);
+
+    expect(data.code).toBe(400);
+    expect(data.message).toBe('test');
+  });
+});

--- a/src/lib/excptions/ApiException.ts
+++ b/src/lib/excptions/ApiException.ts
@@ -1,0 +1,13 @@
+import { ApiErrorScheme } from './type';
+
+class ApiException<ErrorCode = number> extends Error {
+  declare code: ErrorCode;
+
+  constructor(data: ApiErrorScheme, code: ErrorCode) {
+    super(data.message);
+    this.name = 'ApiException';
+    this.code = code;
+  }
+}
+
+export default ApiException;

--- a/src/lib/excptions/CustomException.test.ts
+++ b/src/lib/excptions/CustomException.test.ts
@@ -1,0 +1,12 @@
+import CustomException from '@/lib/excptions/CustomException';
+
+describe('CustomException', () => {
+  const createException = (message:string) => new CustomException(message);
+
+  it('Custom Exception Test', () => {
+    const data = createException('test');
+
+    expect(data.code).toBe('NETWORK_ERROR');
+    expect(data.message).toBe('test');
+  });
+});

--- a/src/lib/excptions/CustomException.ts
+++ b/src/lib/excptions/CustomException.ts
@@ -1,0 +1,11 @@
+class CustomException extends Error {
+  declare code: 'NETWORK_ERROR';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'CustomException';
+    this.code = 'NETWORK_ERROR';
+  }
+}
+
+export default CustomException;

--- a/src/lib/excptions/type.ts
+++ b/src/lib/excptions/type.ts
@@ -1,0 +1,3 @@
+export interface ApiErrorScheme {
+  message: string;
+}

--- a/src/types/ApiTypes.ts
+++ b/src/types/ApiTypes.ts
@@ -1,16 +1,29 @@
 import School from '@/types/School';
 
-export type GetSchoolsResponse = {
+type DefaultResponse = {
+  code: number;
+  message: string;
+};
+
+export type GetSchoolsResponse = DefaultResponse & {
   content: School[];
   first: boolean;
   last: boolean;
   number: number;
 };
 
-export type AuthenticateResponse = {
-  code: number;
-  message: string;
+export type AuthenticateResponse = DefaultResponse & {
   value:{
     token: string;
   }
 };
+
+export type PasswordMissingResponse = DefaultResponse & {
+  value:{
+    userId: number;
+  }
+};
+
+export type PasswordMissingAuthResponse = DefaultResponse;
+
+export type PasswordResetResponse = DefaultResponse;

--- a/src/types/PopInfo.test.ts
+++ b/src/types/PopInfo.test.ts
@@ -1,0 +1,14 @@
+import { getDefaultPopInfo } from './PopInfo';
+
+describe('PopInfo', () => {
+  it('getDefaultPopInfo', () => {
+    const data = getDefaultPopInfo();
+
+    expect(data).toEqual({
+      show: false,
+      title: '',
+      okText: '',
+      onClose: expect.any(Function),
+    });
+  });
+});

--- a/src/types/PopInfo.ts
+++ b/src/types/PopInfo.ts
@@ -1,0 +1,19 @@
+import _ from 'lodash/fp';
+
+type PopInfo = {
+  show: boolean;
+  onClose: () => void;
+  title: string;
+  okText: string;
+  cancelText?: string;
+  onOk?: ()=>void;
+};
+
+export const getDefaultPopInfo = () => ({
+  show: false,
+  title: '',
+  okText: '',
+  onClose: _.noop,
+});
+
+export default PopInfo;


### PR DESCRIPTION
## ⛓ Related Issues
- close #61 

## 📋 작업 내용
- [x] 이메일 인증번호 전송 연동
- [x] 인증번호 인증 연동
- [x] 비밀번호 재설정 연동

## 📌 PR Point
- 현재 서버로 부터 받아온 쿠키가 저장되고 있지 않아서, 진행되지 않음.
- `withCredentials` 옵션을 default로 넣어놨기 때문에 이후에 서버 수정시 문제가 없을 것 같지만 이후 테스트가 필요할 것 같음.